### PR TITLE
PR were also in "Others"

### DIFF
--- a/lib/changelog-gen/generator.js
+++ b/lib/changelog-gen/generator.js
@@ -43,7 +43,7 @@ const groupByLabel = prs => {
 
       // Exclude all changelog:exclude labels
       pr.labels = pr.labels
-        .filter(e => e !== config.labels.exclude)
+        .filter(label => label !== config.labels.exclude)
 
       // Complement
       if (pr.body) {
@@ -59,12 +59,12 @@ const groupByLabel = prs => {
         })
       }
       pr.labels = pr.labels
-        .filter(e => e !== config.labels.complements)
+        .filter(label => label !== config.labels.complements)
 
       pr.labels
-        .filter(e => e.includes('changelog:'))
-        .map(e => {
-          let parsedLabel = e.replace('changelog:', '').replace('-', ' ')
+        .filter(label => label.indexOf('changelog:') > -1)
+        .map(label => {
+          let parsedLabel = label.replace('changelog:', '').replace('-', ' ')
           parsedLabel = parsedLabel.charAt(0).toUpperCase() + parsedLabel.slice(1)
 
           if (!parts[parsedLabel]) {
@@ -73,15 +73,21 @@ const groupByLabel = prs => {
           parts[parsedLabel].push(pr)
         })
 
-      pr.labels
-        .filter(e => !e.includes('changelog:'))
-        .map(() => {
-          if (!parts[config.labels.default]) {
-            parts[config.labels.default] = []
-          }
-          parts[config.labels.default].push(pr)
-        })
+      // Others
+      let hasChangelog = false
 
+      pr.labels.forEach(label => {
+        if (label.indexOf('changelog:') > -1) {
+          hasChangelog = true
+        }
+      })
+
+      if (!hasChangelog) {
+        if (!parts[config.labels.default]) {
+          parts[config.labels.default] = []
+        }
+        parts[config.labels.default].push(pr)
+      }
       delete pr.labels
     }
   }


### PR DESCRIPTION
# Description

This PR fix a bug in the case where a PR is labelized "changelog:..." AND another label will be put under the right label and also in the "Others" label.

# Related issue

* #19 