### PR TITLE
[hotfix] Init remote branch if it doesn't exist

### DIFF
--- a/lib/release-mgr/branch.js
+++ b/lib/release-mgr/branch.js
@@ -16,7 +16,7 @@ module.exports = class Branch {
   push() {
     return exec(this.projectPath, [
       `git commit -am "Release ${this.tag}"`,
-      `git push origin ${this.tag}-proposal`]);
+      `git push --set-upstream origin ${this.tag}-proposal`]);
   }
 
   delete() {


### PR DESCRIPTION
This PR fix the release tool way to push a branch. By init the remote one on push using `--set-upstream` Git option.

Before this fix, you could get this kind of error:

```
New repository tag: 6.1.1                                                                                                                                                                                                                 
CHANGELOG written in changelogs/kuzzleio.sdk-javascript.6.CHANGELOG.md                                                                                                                                                                    
Switched to branch '6.1.1-proposal'                                                                                                                                                                                                       
                                                                                                                                                                                                                                          
fatal: The current branch 6.1.1-proposal has no upstream branch.                                                                                                                                                                          
To push the current branch and set the remote as upstream, use                                                                                                                                                                            
                                                                                                                                                                                                                                          
    git push --set-upstream origin 6.1.1-proposal                                                                                                                                                                                         
                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                          
An error occured: cleaning up.                                                                                                                                                                                                            
Error: Command failed: git push --set-upstream                                                                                                                                                                                            
fatal: The current branch 6.1.1-proposal has no upstream branch.                                                                                                                                                                          
To push the current branch and set the remote as upstream, use                                                                                                                                                                            
                                                                                                                                                                                                                                          
    git push --set-upstream origin 6.1.1-proposal                                                                                                                                                                                         
                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                          
    at ChildProcess.exithandler (child_process.js:275:12)                                                                                                                                                                                 
    at emitTwo (events.js:126:13)                                                                                                                                                                                                         
    at ChildProcess.emit (events.js:214:7)                                                                                                                                                                                                
    at maybeClose (internal/child_process.js:925:16)                                                                                                                                                                                      
    at Socket.stream.socket.on (internal/child_process.js:346:11)                                                                                                                                                                         
    at emitOne (events.js:116:13)                                                                                                                                                                                                         
    at Socket.emit (events.js:211:7)                                                                                                                                                                                                      
    at Pipe._handle.close [as _onclose] (net.js:567:12) 
``` 