### PR TITLE
Fix release 'git push --set-upstream'

### DIFF
--- a/lib/release-mgr/branch.js
+++ b/lib/release-mgr/branch.js
@@ -16,7 +16,7 @@ module.exports = class Branch {
   push() {
     return exec(this.projectPath, [
       `git commit -am "Release ${this.tag}"`,
-      `git push --set-upstream origin ${this.tag}-proposal`]);
+      `git push`]);
   }
 
   delete() {

--- a/lib/release-mgr/bumper.js
+++ b/lib/release-mgr/bumper.js
@@ -12,7 +12,7 @@ function bumpVersion (projectPath, packageInfo, newVersion) {
       if (packageInfo.name === 'package.json') {
         return exec(projectPath, [
           `npm version --allow-same-version --no-git-tag-version ${newVersion}`,
-          'git push --set-upstream'])
+          `git push --set-upstream origin ${newVersion}-proposal`])
           .then(() => resolve())
           .catch(e => reject(e));
       }


### PR DESCRIPTION
# What this PR do ?

Fix a bug which prevented to properly `git push` on the new release branch because the `-set--upstream` was misplaced.