### PR TITLE
Pass Github's access token as a HTTP header

### DIFF
--- a/lib/changelog.js
+++ b/lib/changelog.js
@@ -227,10 +227,11 @@ Then a release can be performed using this tool, using the argument:
     return new Promise((resolve, reject) => {
       https.get({
         headers: {
-          'user-agent': 'ci-changelog'
+          'user-agent': 'ci-changelog',
+          'authorization': `token ${this.token}`,
         },
         host: config.github.api,
-        path: `/repos/${this.owner}/${this.repo}/issues/${id}?access_token=${this.token}`
+        path: `/repos/${this.owner}/${this.repo}/issues/${id}`
       }, response => {
         let str = '';
 

--- a/lib/publisher/publisher.js
+++ b/lib/publisher/publisher.js
@@ -14,9 +14,10 @@ module.exports = class Publisher {
   publish(changelog, draft, prerelease) {
     return rp({
       method: 'POST',
-      uri: `https://${config.github.api}/repos/${this.owner}/${this.repo}/releases?access_token=${this.ghToken}`,
+      uri: `https://${config.github.api}/repos/${this.owner}/${this.repo}/releases`,
       headers: {
-        'user-agent': 'ci-changelog'
+        'user-agent': 'ci-changelog',
+        'authorization': `token ${this.ghToken}`,
       },
       body: {
         target_commitish: this.targetBranch,

--- a/lib/release-mgr/pull-request.js
+++ b/lib/release-mgr/pull-request.js
@@ -13,10 +13,11 @@ module.exports = class PullRequest {
 
   create(changelog) {
     return rp({
-      uri: `https://${config.github.api}/repos/${this.owner}/${this.repo}/pulls?access_token=${this.ghToken}`,
+      uri: `https://${config.github.api}/repos/${this.owner}/${this.repo}/pulls`,
       method: 'POST',
       headers: {
-        'user-agent': 'ci-changelog'
+        'user-agent': 'ci-changelog',
+        'authorization': `token ${this.ghToken}`,
       },
       body: {
         title: `Release ${this.tag}`,
@@ -31,9 +32,10 @@ module.exports = class PullRequest {
   updateLabels(number) {
     return rp({
       method: 'PATCH',
-      uri: `https://${config.github.api}/repos/${this.owner}/${this.repo}/issues/${number}?access_token=${this.ghToken}`,
+      uri: `https://${config.github.api}/repos/${this.owner}/${this.repo}/issues/${number}`,
       headers: {
-        'User-Agent': 'ci-changelog'
+        'User-Agent': 'ci-changelog',
+        'authorization': `token ${this.ghToken}`,
       },
       body: {
         labels: ['release']


### PR DESCRIPTION
# Description

Pass the github's access token using the `Authorization` HTTP header instead of the old `access_token` GET API variable, which is [now deprecated and will be removed in the next few months](https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/)