### PR TITLE
Github's access token must now be passed in http headers

### DIFF
--- a/checkUpdate.js
+++ b/checkUpdate.js
@@ -45,24 +45,24 @@ async function run() {
   }
 }
 
-function apiRequest (url, querystring = {}) {
-  const
-    qs = Object.assign({access_token: args.token, per_page: 999}, querystring),
-    uri = `https://${config.github.api}/${url}`,
-    options = {
-      qs,
-      uri,
-      json: true,
-      headers: {
-        'User-Agent': 'Request-Promise'
-      }
-    };
+async function apiRequest (url, querystring = {}) {
+  const uri = `https://${config.github.api}/${url}`;
 
-  return rp(options)
-    .catch(error => {
-      console.error(`\x1b[31mGithub API call failed on URL: ${uri}\x1b[0m`);
-      throw error;
+  try {
+    return await rp({
+      headers: {
+        'user-agent': 'ci-changelog',
+        'authorization': `token ${args.token}`,
+      },
+      json: true,
+      qs: Object.assign({per_page: 999}, querystring),
+      uri,
     });
+  }
+  catch(error) {
+    console.error(`\x1b[31mGithub API call failed on URL: ${uri}\x1b[0m`);
+    throw error;
+  }
 }
 
 async function getBranches(repo) {

--- a/publish.js
+++ b/publish.js
@@ -77,12 +77,18 @@ async function run() {
 
 async function getLatestRelease(owner, repo, releaseBranch) {
   const result = await rp({
-    uri: `https://${config.github.api}/search/issues?q=base:${releaseBranch}+repo:${owner}/${repo}+label:release+is:merged&access_token=${args.token}&sort=updated&order=desc`,
+    uri: `https://${config.github.api}/search/issues`,
+    qs: {
+      q: `base:${releaseBranch}+repo:${owner}/${repo}+label:release+is:merged`,
+      sort: 'updated',
+      order: 'desc',
+    },
     method: 'GET',
     headers: {
-      'user-agent': 'ci-changelog'
+      'authorization': `token ${args.token}`,
+      'user-agent': 'ci-changelog',
     },
-    json: true
+    json: true,
   });
 
   if (result.total_count === 0) {


### PR DESCRIPTION
# Description

Github has deprecated the `access_token` parameter in query strings: it must now be passed in HTTP headers.